### PR TITLE
loop configuration

### DIFF
--- a/behave/configuration.py
+++ b/behave/configuration.py
@@ -95,6 +95,10 @@ options = [
      dict(metavar="PATTERN", dest="include_re",
           help="Only run feature files matching regular expression PATTERN.")),
 
+    (("-l", "--loop"),
+     dict(action="store", default=1, type=int,
+          help="Define loop number to execute tests")),
+
     (("--no-junit",),
      dict(action="store_false", dest="junit",
           help="Don't output JUnit-compatible reports.")),


### PR DESCRIPTION
Add new loop configuration parameter to run tests more than once.
This allows to have only one report for the same tests running
several times.